### PR TITLE
Fix prose heading hierarchy for blog posts

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -498,17 +498,16 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 .prose h2 {
   font-family: var(--display);
   font-weight: 500;
-  font-size: 19px;
+  font-size: 1.5rem;
   margin: 32px 0 10px;
   color: var(--ink);
   letter-spacing: -0.01em;
 }
 .prose h3 {
-  font-family: var(--ui);
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--ink-3);
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: 1.25rem;
+  color: var(--ink);
   margin: 28px 0 8px;
 }
 .prose ul { padding-left: 18px; }


### PR DESCRIPTION
## Summary

- `.prose h2` was 19px Spectral, only 1.08x body text — barely registered as a heading. Now `1.5rem` (24px, ~1.37x body).
- `.prose h3` was 11px JetBrains Mono uppercase tracked-out label, *smaller* than body text. Now `1.25rem` (20px, ~1.14x body) Spectral, normal case, no letter-spacing, full ink color — sized between h2 and body so the hierarchy reads correctly.
- Sizes use `rem` so user font-size preferences scale them; rest of the stylesheet is left in `px` (separate effort).

## Why this matters

Blog posts on the site had broken visual hierarchy: subheadings were either indistinguishable from paragraphs (h2) or styled as tiny eyebrow labels (h3). Readers got no structural signal when scanning long posts.

## h3 audit

I grepped every post under `content/blog/*.html` for `<h3` before changing the styling to make sure no post relied on the old tiny-uppercase look as an intentional eyebrow/label. Findings:

- 5 posts use `<h3>`: `12-factor-engineering-best-practices.html`, `future-of-work-with-ai.html`, `skills-are-just-markdown.html`, `llm-agents-gentle-introduction.html`, `you-might-still-need-a-useeffect.html`.
- Every single h3 is a real subheading ("Reasoning", "Factor 1: Codebase", "The dependency array decides when to re-run the callback", etc.). None are labels/eyebrows.
- Existing eyebrow styling already lives elsewhere as `.page-eyebrow` / `.note-eyebrow`, so no need to introduce a `.prose .eyebrow` class for a use case nobody has.

Smallest blast radius: change the CSS only, leave content untouched.

## Out of scope

- Did not touch h1, body, dek, intro, footer, or homepage typography.
- Did not migrate the rest of `app.css` to rem.
- Did not touch the INEC component or post (covered by a separate landed PR).

## Test plan

- [x] `npm run build` passes (pre-existing SEO length warnings unrelated to this change).
- [ ] Open `/blog/you-might-still-need-a-useeffect.html` and confirm h2 is distinctly larger than body, h3 sits between h2 and body, both read as headings rather than labels.
- [ ] Spot-check `/blog/skills-are-just-markdown.html` (lots of h3s) and `/blog/12-factor-engineering-best-practices.html` (12 h3 factor headings) for the same.
- [ ] Confirm no post that previously had a meaningful h3 looks broken — none should, since no post used h3 as an eyebrow.