### PR TITLE
Add Google Analytics + technical SEO improvements

### DIFF
--- a/src/builder/outputs/articles.js
+++ b/src/builder/outputs/articles.js
@@ -7,7 +7,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { LAYOUTS_DIR } from "../config.js";
 import { stampBlogPost, stampComponents } from "../render.js";
-import { renderArticleOgExtras, renderJsonLd, renderOgTags } from "../seo.js";
+import { renderAnalytics, renderArticleOgExtras, renderJsonLd, renderOgTags } from "../seo.js";
 import { escapeHtml } from "../utils.js";
 import { writeFile } from "../fs-helpers.js";
 
@@ -60,7 +60,8 @@ async function renderArticlePage(article, layout, publishedArticles) {
 
   return html.replace(
     "<!--%og%-->",
-    `${og}
+    `${renderAnalytics()}
+    ${og}
     ${articleExtras}
     ${robots}
     ${jsonLd}`

--- a/src/builder/outputs/articles.js
+++ b/src/builder/outputs/articles.js
@@ -7,7 +7,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { LAYOUTS_DIR } from "../config.js";
 import { stampBlogPost, stampComponents } from "../render.js";
-import { renderAnalytics, renderArticleOgExtras, renderJsonLd, renderOgTags } from "../seo.js";
+import {
+  renderAnalytics,
+  renderArticleOgExtras,
+  renderJsonLd,
+  renderOgTags,
+  renderWebSiteJsonLd,
+} from "../seo.js";
 import { escapeHtml } from "../utils.js";
 import { writeFile } from "../fs-helpers.js";
 
@@ -64,6 +70,7 @@ async function renderArticlePage(article, layout, publishedArticles) {
     ${og}
     ${articleExtras}
     ${robots}
+    ${renderWebSiteJsonLd()}
     ${jsonLd}`
   );
 }

--- a/src/builder/outputs/categories.js
+++ b/src/builder/outputs/categories.js
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SRC, site } from "../config.js";
 import { renderArchive, stampComponents } from "../render.js";
-import { renderOgTags } from "../seo.js";
+import { renderAnalytics, renderOgTags } from "../seo.js";
 import { writeFile } from "../fs-helpers.js";
 import { escapeHtml, slugify } from "../utils.js";
 
@@ -64,10 +64,11 @@ async function renderCategoryPage({ slug, name, articles, layout, publishedArtic
 
   return html.replace(
     "<!--%og%-->",
-    renderOgTags({
+    `${renderAnalytics()}
+    ${renderOgTags({
       title: `${name} | Blog | ${site.name}`,
       description: `Essays tagged ${name}.`,
       url: `/blog/category/${slug}.html`,
-    })
+    })}`
   );
 }

--- a/src/builder/outputs/categories.js
+++ b/src/builder/outputs/categories.js
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SRC, site } from "../config.js";
 import { renderArchive, stampComponents } from "../render.js";
-import { renderAnalytics, renderOgTags } from "../seo.js";
+import { renderAnalytics, renderOgTags, renderWebSiteJsonLd } from "../seo.js";
 import { writeFile } from "../fs-helpers.js";
 import { escapeHtml, slugify } from "../utils.js";
 
@@ -69,6 +69,7 @@ async function renderCategoryPage({ slug, name, articles, layout, publishedArtic
       title: `${name} | Blog | ${site.name}`,
       description: `Essays tagged ${name}.`,
       url: `/blog/category/${slug}.html`,
-    })}`
+    })}
+    ${renderWebSiteJsonLd()}`
   );
 }

--- a/src/builder/outputs/pages.js
+++ b/src/builder/outputs/pages.js
@@ -7,7 +7,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SRC, site } from "../config.js";
 import { stampComponents } from "../render.js";
-import { renderAnalytics, renderOgTags } from "../seo.js";
+import {
+  renderAnalytics,
+  renderOgTags,
+  renderPersonJsonLd,
+  renderWebSiteJsonLd,
+} from "../seo.js";
 import { writeFile } from "../fs-helpers.js";
 
 /** @typedef {import("../articles.js").Article} Article */
@@ -43,10 +48,13 @@ export async function buildPages(publishedArticles) {
 
     html = html.replace("<!--%notes-count-->", String(publishedArticles.length));
     html = await stampComponents(html, publishedArticles);
+    const personLd = page.url === "/" ? renderPersonJsonLd() : "";
     html = html.replace(
       "<!--%og%-->",
       `${renderAnalytics()}
-    ${renderOgTags({ title: page.title, description: page.description, url: page.url })}`
+    ${renderOgTags({ title: page.title, description: page.description, url: page.url })}
+    ${renderWebSiteJsonLd()}
+    ${personLd}`
     );
 
     await writeFile(page.dest, html);

--- a/src/builder/outputs/pages.js
+++ b/src/builder/outputs/pages.js
@@ -7,7 +7,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SRC, site } from "../config.js";
 import { stampComponents } from "../render.js";
-import { renderOgTags } from "../seo.js";
+import { renderAnalytics, renderOgTags } from "../seo.js";
 import { writeFile } from "../fs-helpers.js";
 
 /** @typedef {import("../articles.js").Article} Article */
@@ -45,7 +45,8 @@ export async function buildPages(publishedArticles) {
     html = await stampComponents(html, publishedArticles);
     html = html.replace(
       "<!--%og%-->",
-      renderOgTags({ title: page.title, description: page.description, url: page.url })
+      `${renderAnalytics()}
+    ${renderOgTags({ title: page.title, description: page.description, url: page.url })}`
     );
 
     await writeFile(page.dest, html);

--- a/src/builder/seo.js
+++ b/src/builder/seo.js
@@ -8,6 +8,25 @@ import { escapeHtml } from "./utils.js";
 
 /** @typedef {import("./articles.js").Article} Article */
 
+const GA_MEASUREMENT_ID = "G-D8YJEFRG9M";
+
+/**
+ * Render the Google Analytics gtag snippet. The `async` attribute keeps the
+ * loader script off the critical path; the inline config block initialises
+ * dataLayer before the loader resolves.
+ *
+ * @returns {string}
+ */
+export function renderAnalytics() {
+  return `<script async src="https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '${GA_MEASUREMENT_ID}');
+    </script>`;
+}
+
 /**
  * @typedef {Object} OgInput
  * @property {string} title

--- a/src/builder/seo.js
+++ b/src/builder/seo.js
@@ -95,13 +95,14 @@ export function renderArticleOgExtras(article) {
 }
 
 /**
- * Render the JSON-LD BlogPosting block for an article.
+ * Render the JSON-LD blocks for an article: a BlogPosting plus a
+ * BreadcrumbList (Home → Blog → Post Title).
  *
  * @param {Article} article
  */
 export function renderJsonLd(article) {
   const base = site.url.replace(/\/$/, "");
-  const data = {
+  const blogPosting = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: article.title,
@@ -125,10 +126,64 @@ export function renderJsonLd(article) {
     keywords: article.categories.join(", "),
   };
   if (article.ogImage) {
-    data.image = article.ogImage.startsWith("http")
+    blogPosting.image = article.ogImage.startsWith("http")
       ? article.ogImage
       : base + article.ogImage;
   }
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: base + "/" },
+      { "@type": "ListItem", position: 2, name: "Notes", item: base + "/blog/" },
+      { "@type": "ListItem", position: 3, name: article.title, item: base + article.url },
+    ],
+  };
+
+  return [blogPosting, breadcrumb]
+    .map((d) => `<script type="application/ld+json">${JSON.stringify(d, null, 2)}</script>`)
+    .join("\n    ");
+}
+
+/**
+ * Render the JSON-LD Person block for the site author. Used on the homepage
+ * and any other page that represents the author directly.
+ *
+ * @returns {string}
+ */
+export function renderPersonJsonLd() {
+  const base = site.url.replace(/\/$/, "");
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: site.author,
+    url: base,
+    sameAs: [
+      "https://github.com/tosinamuda",
+      "https://linkedin.com/in/tosinamuda",
+      "https://twitter.com/tosinamuda",
+    ],
+  };
+  return `<script type="application/ld+json">${JSON.stringify(data, null, 2)}</script>`;
+}
+
+/**
+ * Render the JSON-LD WebSite block. Emitted on every page so search engines
+ * can associate site-level metadata with any entry point.
+ *
+ * @returns {string}
+ */
+export function renderWebSiteJsonLd() {
+  const base = site.url.replace(/\/$/, "");
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: site.name,
+    url: base,
+    description: site.description,
+    inLanguage: site.locale,
+  };
   return `<script type="application/ld+json">${JSON.stringify(data, null, 2)}</script>`;
 }
 

--- a/src/builder/seo.js
+++ b/src/builder/seo.js
@@ -53,8 +53,9 @@ export function renderOgTags({ title, description, url, image, type = "website" 
     <meta name="twitter:image" content="${escapeHtml(absoluteImage)}" />`
     : "";
 
-  const twitterCreator = site.twitterHandle
-    ? `<meta name="twitter:creator" content="${escapeHtml(site.twitterHandle)}" />`
+  const twitterAccount = site.twitterHandle
+    ? `<meta name="twitter:site" content="${escapeHtml(site.twitterHandle)}" />
+    <meta name="twitter:creator" content="${escapeHtml(site.twitterHandle)}" />`
     : "";
 
   return `<link rel="canonical" href="${escapeHtml(absoluteUrl)}" />
@@ -67,7 +68,7 @@ export function renderOgTags({ title, description, url, image, type = "website" 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="${safeTitle}" />
     <meta name="twitter:description" content="${safeDesc}" />
-    ${twitterCreator}
+    ${twitterAccount}
     ${imgTags}`;
 }
 


### PR DESCRIPTION
## Summary

HTML / build-script-only SEO pass. No CSS, no INEC component, no new dependencies.

- **Google Analytics**: gtag.js (`G-D8YJEFRG9M`) injected on every generated page (static, articles, category archives) via a new `renderAnalytics()` helper in `src/builder/seo.js`. Loads early (right after `<title>` / `<meta description>`) and async, so it doesn't block content.
- **Canonical URLs**: already emitted by `renderOgTags()`. Verified present on home, blog index, articles, and category pages.
- **Twitter cards**: `twitter:site` added alongside the existing `twitter:creator`. The `summary_large_image` card variant was already in place.
- **JSON-LD expansion**:
  - `Person` on the homepage, with `sameAs` pointing at GitHub, LinkedIn, Twitter.
  - `WebSite` on every page (name, URL, locale, description).
  - `BreadcrumbList` on every blog post (Home → Notes → Title), in addition to the existing `BlogPosting`.
  - Validated all blocks parse as JSON.
- **robots.txt**: already present at `public/robots.txt` with the correct sitemap reference. No change needed.
- **Static page meta descriptions**: every static page already has a factual `<meta name="description">`. No edits.

## Per-post OG image audit

**All 17 posts in `content/blog/` fall back to the default OG image** (`/og/default.png`). None set `og-image` on `<blog-post>` or `ogImage` in their meta JSON. Worth knowing if you want to prioritise unique images for the most-shared ones:

- 12-factor-engineering-best-practices
- 2023-a-journey-through-loss-and-resilience
- a-letter-to-an-outgoing-corper-episode-one
- building-kids-into-whizkids
- finetuning-llama-with-dspy-on-sagemaker (draft)
- future-of-work-with-ai (draft)
- how-to-containerize-a-react-application
- inec-presidential-election-collation-architecture
- interesting-concept-eliminate-stupid-mental-effort-esme
- llm-agents-gentle-introduction
- react-antipatterns-worth-fixing (draft)
- resurrected-from-the-dead
- skills-are-just-markdown (draft)
- the-lie-about-the-future
- todays-sci-fi-and-tomorrows-reality-4-future-technologies
- understanding-serverless-using-restaurant-server-analogy
- you-might-still-need-a-useeffect

## Draft `noindex` verification

All 4 drafts have `noindex, nofollow`:
- `finetuning-llama-with-dspy-on-sagemaker.html`
- `future-of-work-with-ai.html`
- `react-antipatterns-worth-fixing.html`
- `skills-are-just-markdown.html`

No published post has `noindex`. Working as expected.

## Posts with long titles / excerpts (>60 / >160 chars)

The build emits warnings for these. Editorial work, not part of this PR — flagging for the author:

- `2023-a-journey-through-loss-and-resilience` — excerpt 193
- `building-kids-into-whizkids` — excerpt 272
- `inec-presidential-election-collation-architecture` — title 139, excerpt 245
- `interesting-concept-eliminate-stupid-mental-effort-esme` — title 71, excerpt 217
- `resurrected-from-the-dead` — excerpt 278
- `skills-are-just-markdown` (draft) — excerpt 227
- `the-lie-about-the-future` — excerpt 292
- `todays-sci-fi-and-tomorrows-reality-4-future-technologies` — title 81, excerpt 166
- `understanding-serverless-using-restaurant-server-analogy` — excerpt 175

## Test plan

- [x] `npm run build` passes; `verify.js` checks pass.
- [x] gtag present in source on every generated page (34/34 HTML files in `dist/`).
- [x] Canonical URL present on home, blog index, articles, category pages.
- [x] `twitter:card`, `twitter:site`, `twitter:creator`, `twitter:title`, `twitter:description`, `twitter:image` present.
- [x] JSON-LD blocks (WebSite, Person, BlogPosting, BreadcrumbList) all parse as valid JSON.
- [x] `dist/sitemap.xml` generated (30 `<loc>` entries).
- [x] `dist/robots.txt` accessible and references the sitemap.
- [x] All 4 drafts emit `noindex, nofollow`; no published post does.

## Notes

- HTML / build-only — does not touch `.css` or the INEC component, so no expected conflict with PR #12 or recent merges.
- No privacy/cookie banner added — out of scope per the brief.
- No vendor verification meta (Bing, etc.) added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)