### PR TITLE
[codex] Fix static site reflow

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -7,6 +7,9 @@
     <meta name="description" content="About Tosin Amuda. Software engineer at IBM, MSc on lesson-plan-driven personalised learning." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -53,7 +56,7 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/blog.html
+++ b/src/blog.html
@@ -7,6 +7,9 @@
     <meta name="description" content="All notes, newest first." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -25,8 +28,8 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
-    <script type="module" src="/components/blog-archive.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/blog-archive.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/builder/render.js
+++ b/src/builder/render.js
@@ -59,6 +59,24 @@ function wrapElement(tag, attrs, children) {
   return `<${tag}${attrStr}>${children}</${tag}>`;
 }
 
+const HEADER_SUBTITLE_BY_ACTIVE = {
+  home: "/ notes",
+  blog: "/ notes",
+  note: "/ notes",
+  work: "/ work",
+  about: "/ about",
+  contact: "/ contact",
+};
+
+const HEADER_NAV_BY_ACTIVE = {
+  home: "home",
+  blog: "home",
+  note: "home",
+  work: "work",
+  about: "about",
+  contact: "contact",
+};
+
 // ───────────────────────────────────────────────────────
 //  Archive rendering
 //
@@ -175,8 +193,8 @@ export function renderRelated(article, allArticles) {
 //
 //  Server-renders the contents of <site-header>, <site-footer>, and
 //  <blog-archive> custom elements so the page is meaningful without JS.
-//  The original custom-element tags are preserved for any client-side
-//  enhancement (e.g. `is-current` nav highlighting).
+//  The original custom-element tags are preserved for client-side enhancement,
+//  but visible header state is rendered here to avoid post-load layout shifts.
 // ───────────────────────────────────────────────────────
 
 /**
@@ -192,7 +210,7 @@ export async function stampComponents(html, articles) {
 
   html = html.replace(
     /<site-header([^>]*)><\/site-header>/g,
-    (_m, attrs) => wrapElement("site-header", attrs.trim(), headerTpl)
+    (_m, attrs) => wrapElement("site-header", attrs.trim(), renderHeader(headerTpl, attrs))
   );
   html = html.replace(
     /<site-footer([^>]*)><\/site-footer>/g,
@@ -214,6 +232,34 @@ export async function stampComponents(html, articles) {
     html = html.replace(
       /<inec-collation([^>]*)><\/inec-collation>/g,
       (_m, attrs) => wrapElement("inec-collation", attrs.trim(), inecTpl)
+    );
+  }
+
+  return html;
+}
+
+/**
+ * Render header state that would otherwise be applied after the component
+ * module loads. This keeps the Web Component runtime while making first paint
+ * match the enhanced state.
+ *
+ * @param {string} template
+ * @param {string} attrs
+ */
+function renderHeader(template, attrs) {
+  const active = attrs.match(/active="([^"]+)"/)?.[1] ?? "";
+  let html = template;
+
+  const subtitle = HEADER_SUBTITLE_BY_ACTIVE[active];
+  if (subtitle) {
+    html = html.replace(/<span class="sub">[^<]*<\/span>/, `<span class="sub">${subtitle}</span>`);
+  }
+
+  const nav = HEADER_NAV_BY_ACTIVE[active];
+  if (nav) {
+    html = html.replace(
+      new RegExp(`(<a href="[^"]+" data-nav="${nav}")([^>]*>)`),
+      (_match, start, end) => `${start} class="is-current"${end}`
     );
   }
 

--- a/src/builder/verify.js
+++ b/src/builder/verify.js
@@ -31,4 +31,32 @@ export async function verify() {
   for (const f of REQUIRED) {
     await fs.access(path.join(ROOT, f));
   }
+
+  await verifyRuntimeContracts();
+}
+
+async function verifyRuntimeContracts() {
+  const pages = [
+    ["dist/index.html", 'data-nav="home" class="is-current"'],
+    ["dist/blog/index.html", 'data-nav="home" class="is-current"'],
+    ["dist/about.html", 'data-nav="about" class="is-current"'],
+    ["dist/work.html", 'data-nav="work" class="is-current"'],
+    ["dist/contact.html", 'data-nav="contact" class="is-current"'],
+  ];
+
+  for (const [file, activeNavMarkup] of pages) {
+    const html = await fs.readFile(path.join(ROOT, file), "utf8");
+    if (!html.includes(activeNavMarkup)) {
+      throw new Error(`${file} is missing server-rendered active navigation`);
+    }
+    if (!html.includes('rel="preload" href="/fonts/spectral-400.woff2" as="font"')) {
+      throw new Error(`${file} is missing the critical Spectral font preload`);
+    }
+    if (!html.includes('src="/components/site-header.js" defer crossorigin="anonymous"')) {
+      throw new Error(`${file} is missing crossorigin on the site-header module`);
+    }
+    if (html.includes("static.cloudflareinsights.com/beacon.min.js")) {
+      throw new Error(`${file} hardcodes Cloudflare Web Analytics instead of leaving it to hosting`);
+    }
+  }
 }

--- a/src/category.html
+++ b/src/category.html
@@ -7,6 +7,9 @@
     <meta name="description" content="Notes tagged %category%." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -28,8 +31,8 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
-    <script type="module" src="/components/blog-archive.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/blog-archive.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/components/site-header.js
+++ b/src/components/site-header.js
@@ -7,16 +7,28 @@ const SUB_MAP = {
   contact: "/ contact",
 };
 
+const NAV_MAP = {
+  home: "home",
+  blog: "home",
+  note: "home",
+  work: "work",
+  about: "about",
+  contact: "contact",
+};
+
 class SiteHeader extends HTMLElement {
   connectedCallback() {
     const active = this.getAttribute("active");
     if (!active) return;
 
-    const link = this.querySelector(`a[data-nav="${active}"]`);
+    const nav = NAV_MAP[active];
+    const link = nav ? this.querySelector(`a[data-nav="${nav}"]`) : null;
     if (link) link.classList.add("is-current");
 
     const sub = this.querySelector(".brand .sub");
-    if (sub && SUB_MAP[active]) sub.textContent = SUB_MAP[active];
+    if (sub && SUB_MAP[active] && sub.textContent !== SUB_MAP[active]) {
+      sub.textContent = SUB_MAP[active];
+    }
   }
 }
 

--- a/src/contact.html
+++ b/src/contact.html
@@ -7,6 +7,9 @@
     <meta name="description" content="Best ways to reach Tosin Amuda." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -38,7 +41,7 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
     <meta name="description" content="Notes from a software engineer. AI systems and engineering, with occasional personal reflections." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -21,8 +24,8 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
-    <script type="module" src="/components/blog-archive.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/blog-archive.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/layouts/article.html
+++ b/src/layouts/article.html
@@ -7,6 +7,9 @@
     <meta name="description" content="%excerpt%" />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -17,11 +20,11 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
-    <script type="module" src="/components/blog-archive.js" defer></script>
-    <script type="module" src="/components/blog-post.js" defer></script>
-    <script type="module" src="/components/code-block.js" defer></script>
-    <script type="module" src="/components/inec-collation.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/blog-archive.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/blog-post.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/code-block.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/inec-collation.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9,35 +9,35 @@
   font-family: "JetBrains Mono";
   font-style: normal;
   font-weight: 400 500;
-  font-display: swap;
+  font-display: optional;
   src: url("/fonts/jetbrains-mono.woff2") format("woff2");
 }
 @font-face {
   font-family: "Spectral";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: optional;
   src: url("/fonts/spectral-400.woff2") format("woff2");
 }
 @font-face {
   font-family: "Spectral";
   font-style: normal;
   font-weight: 500;
-  font-display: swap;
+  font-display: optional;
   src: url("/fonts/spectral-500.woff2") format("woff2");
 }
 @font-face {
   font-family: "Spectral";
   font-style: normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: optional;
   src: url("/fonts/spectral-600.woff2") format("woff2");
 }
 @font-face {
   font-family: "Spectral";
   font-style: italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: optional;
   src: url("/fonts/spectral-italic.woff2") format("woff2");
 }
 

--- a/src/work.html
+++ b/src/work.html
@@ -7,6 +7,9 @@
     <meta name="description" content="Applied projects, research, and experiments across AI systems: agents, conversational interfaces, and AI in education." />
     <!--%og%-->
     <link rel="icon" href="/icon.png" type="image/png" />
+    <link rel="preload" href="/fonts/spectral-400.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/spectral-500.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href="/assets/styles.css" />
     <link rel="alternate" type="application/atom+xml" title="Tosin Amuda · Notes" href="/feed.xml" />
   </head>
@@ -47,7 +50,7 @@
       <site-footer></site-footer>
     </main>
 
-    <script type="module" src="/components/site-header.js" defer></script>
-    <script type="module" src="/components/site-footer.js" defer></script>
+    <script type="module" src="/components/site-header.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/site-footer.js" defer crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the delayed visual reflow seen after page load while keeping the existing Web Component runtime and Cloudflare-managed behavior intact.

## What changed

- Build-render the header active state into the generated static HTML so the visible nav underline/subtitle does not appear after the component module loads.
- Keep Web Component scripts in place and add `crossorigin="anonymous"` to match module request credentials and address Rocket Loader preload credential warnings.
- Preload the critical self-hosted fonts before the stylesheet.
- Switch self-hosted fonts from `font-display: swap` to `optional` to avoid late metric-changing font swaps.
- Add build verification for active nav HTML, font preload, component script `crossorigin`, and absence of hardcoded Cloudflare Web Analytics.

## Notes

- This does not add Cloudflare Web Analytics source code. Cloudflare can continue injecting its own beacon when enabled in Pages/proxy settings.
- This does not disable Cloudflare email obfuscation.
- Google Analytics remains the existing source-controlled `G-D8YJEFRG9M` snippet.

## Validation

- `npm test`
- `git diff --check`
- Local browser check on homepage: component modules present with `crossOrigin: "anonymous"`, critical font preloads present, no layout-shift entries after 3s.
- Local browser check on article page: Web Component code-block enhancement still created 22 copy buttons.