### PR TITLE
Add Global South AI value chain article

### DIFF
--- a/content/blog/building-a-generative-ui-agent-for-bob-with-bob-by-bob.html
+++ b/content/blog/building-a-generative-ui-agent-for-bob-with-bob-by-bob.html
@@ -17,10 +17,6 @@
 
     <p>The experience was built for Bob, the harness that made it possible was built with Bob, and every app a visitor saw was authored by Bob. In the rest of this article, I will share how I designed the architecture to handle the booth constraints, what I learned from the execution, and where there is room for improvement.</p>
 
-    <source-note heading="Disclaimer">
-      <p>The views in this essay are personal. They do not represent IBM, the Bob team, or any of my employers.</p>
-    </source-note>
-
     <h2>Design goals</h2>
 
     <p>The loop had to complete while a visitor was still standing there. That single constraint gave the generative UI agent five design goals.</p>
@@ -346,4 +342,8 @@ function PreviewPane({ previewUrl }: { previewUrl: string }) {
     <p>The Think 2026 version proved the core loop: prompt, context, BobShell, workspace, bundle, wrapper, iframe. The next version should make it more self-correcting, safer, and more efficient.</p>
 
     <p>Bob brings the coding agent. The task-specific harness gives it a job.</p>
+
+    <source-note heading="Disclaimer">
+      <p>The views in this essay are personal. They do not represent IBM, the Bob team, or any of my employers.</p>
+    </source-note>
 </blog-post>

--- a/content/blog/building-a-generative-ui-agent-for-bob-with-bob-by-bob.html
+++ b/content/blog/building-a-generative-ui-agent-for-bob-with-bob-by-bob.html
@@ -17,6 +17,10 @@
 
     <p>The experience was built for Bob, the harness that made it possible was built with Bob, and every app a visitor saw was authored by Bob. In the rest of this article, I will share how I designed the architecture to handle the booth constraints, what I learned from the execution, and where there is room for improvement.</p>
 
+    <source-note heading="Disclaimer">
+      <p>The views in this essay are personal. They do not represent IBM, the Bob team, or any of my employers.</p>
+    </source-note>
+
     <h2>Design goals</h2>
 
     <p>The loop had to complete while a visitor was still standing there. That single constraint gave the generative UI agent five design goals.</p>

--- a/content/blog/how-the-global-south-can-enter-the-ai-value-chain-nigerias-case.html
+++ b/content/blog/how-the-global-south-can-enter-the-ai-value-chain-nigerias-case.html
@@ -1,0 +1,67 @@
+<blog-post
+  title="How the Global South Can Enter the AI Value Chain: Nigeria’s Case"
+  excerpt="A Nigeria-focused strategy for entering the AI value chain through open-source models, local data, talent, compute, and diaspora transfer."
+  date="2026-05-13">
+  <script type="application/json" id="meta">
+    { "type": "essay", "categories": ["AI", "Nigeria"] }
+  </script>
+
+<p>I will answer from Nigeria's perspective, though the same logic applies to countries with similar constraints: limited frontier AI capital, shallow advanced research depth, and large populations entering an AI-shaped labour market. Nigeria's AI strategy should be value-chain entry. The country should build the layers of the AI economy it can realistically own now, then use them to move upstream over time.</p>
+
+<p>The first reachable layer is open-source and small-model capability. With open-weight models, Nigerian teams can fine-tune, compress, evaluate, and serve useful systems without frontier-scale compute. Around that layer, Nigeria should build local datasets, evaluation benchmarks, applied AI talent, targeted compute, and diaspora knowledge transfer. The goal is to become production-adjacent now and selectively productive over the decade.</p>
+
+<h2>Start with open-source and small models</h2>
+
+<p>Open-source and small models matter because they give countries outside the frontier a practical production surface. A frontier model may require capital, chips, electricity, and research density that Nigeria does not yet have. A small domain model requires a narrower but reachable stack: good task data, capable engineers, evaluation discipline, inference infrastructure, and enough compute for fine-tuning. That is where Nigeria can start producing capability rather than only watching the frontier move.</p>
+
+<p>The unit of progress should be concrete: a compressed speech model, a curriculum benchmark, a legal retrieval model, a Nigerian-language evaluation suite, a fine-tuned agricultural advisory model, or a low-cost inference service. Each artifact trains people, creates reusable infrastructure, and pushes the country further into the AI value chain.</p>
+
+<h2>Create a National AI Value-Chain Agenda</h2>
+
+<p>The first move is a National AI Value-Chain Agenda. This should not be a broad digital transformation plan. It should map the specific layers where Nigeria can capture value: open-source model adaptation, small-model training, dataset creation, evaluation infrastructure, inference deployment, AI tooling, and applied research.</p>
+
+<p>The agenda should identify which institutions own each layer, how funding flows into them, and what measurable outputs count as progress. A National AI Adviser should coordinate ministries, universities, regulators, cloud providers, research institutes, and private builders, with legislation within the year so the structure survives electoral cycles.</p>
+
+<h2>Fund an Open-Source and Small-Model Programme</h2>
+
+<p>The second move is an Open-Source and Small-Model Programme. Nigeria should support teams that can adapt open-weight models, compress them, evaluate them, and serve them cheaply under local infrastructure constraints. This is not a side project. It is the first production layer available to the country.</p>
+
+<p>The programme should fund model adaptation labs in universities, startup teams building narrow models, and public-interest projects that produce reusable tooling. Success should not be measured by announcements. It should be measured by released models, documented evaluations, lower inference costs, reproducible training pipelines, and engineers who can repeat the work.</p>
+
+<h2>Treat data and evaluation as national infrastructure</h2>
+
+<p>The third move is a Nigerian Data and Evaluation Mission. Data and benchmarks are economic assets, not merely research inputs. Foreign labs have little incentive to curate Yoruba, Hausa, Igbo, Pidgin, and Nigerian English speech data at the quality Nigeria needs. They will not build serious benchmarks for Nigerian curricula, legal procedure, agricultural conditions, clinical workflows, or local administrative tasks unless there is commercial pressure to do so.</p>
+
+<p>Nigeria should therefore fund these datasets and benchmarks as national infrastructure. A country without local data cannot adapt models deeply. A country without local benchmarks cannot tell whether its systems work. A country with both can train, evaluate, negotiate, and build from a position of greater leverage.</p>
+
+<h2>Build an applied AI talent pipeline</h2>
+
+<p>The fourth move is an Applied AI Talent Pipeline. Nigeria's short-term priority should be applied AI engineers and applied researchers: people who can fine-tune models, build retrieval systems, curate datasets, design evaluations, compress models, deploy inference, and monitor failure modes. This group is more urgent than a small number of frontier theorists because it builds the working base on which deeper research depends.</p>
+
+<p>In the medium term, universities should teach discipline-specific AI in fields where the technology will reshape professional work, including medicine, agriculture, education, law, finance, and engineering. In the long term, Nigeria needs PhD-level researchers in machine learning, optimisation, systems, safety, and model architecture. The order matters. Applied work creates the datasets, failures, research questions, and institutional demand that make serious doctoral research viable locally.</p>
+
+<h2>Negotiate targeted compute access</h2>
+
+<p>The fifth move is targeted compute access. Nigeria should not begin by trying to match hyperscale training clusters. It needs compute for inference, fine-tuning, evaluation, synthetic data generation, and small-model training. The immediate step is to negotiate cloud credit pools with major cloud providers for accredited researchers, startups, and public-interest teams.</p>
+
+<p>In parallel, Nigeria should build one reliable, independently powered GPU cluster at a federal university or national research centre, sized for fine-tuning and inference rather than frontier pretraining. Over five years, that cluster can grow into a small national research compute network, located only where power, fibre, cooling, security, and environmental conditions are credible.</p>
+
+<h2>Use diaspora knowledge transfer deliberately</h2>
+
+<p>The sixth move is diaspora knowledge transfer. Nigerians working in frontier labs, cloud companies, AI startups, and research universities abroad are one of the country's fastest routes to frontier exposure. The mechanism should be practical: paid sabbaticals, remote mentorship, joint research, visiting residencies, and later repatriation offers tied to real authority, compute access, and funded teams.</p>
+
+<p>Symbolic homecoming campaigns will not matter if there is no serious infrastructure to join. Diaspora transfer should plug into the open-source programme, data mission, talent pipeline, and compute network.</p>
+
+<h2>Own reachable layers, then climb</h2>
+
+<p>Once these foundations compound, Nigeria can move from production-adjacent capability to selective production. A technically insulated National AI Agency could then coordinate strong small and domain-specific models in areas where Nigeria has data depth, engineering capacity, and sustained demand. Its job would not be to imitate OpenAI. Its job would be to own the parts of the stack where Nigeria can build advantage, then climb from there.</p>
+
+<p>Nigeria will not be sidestepped because it failed to build a frontier model in 2026. It will be sidestepped if it owns no layer of the AI economy: not the datasets, not the benchmarks, not the model adaptation labs, not the inference infrastructure, not the applied talent pipeline, and not the research institutions that turn today's tools into tomorrow's capability. The first task is to own the layers within reach. Then climb.</p>
+
+<source-note id="origin-note" heading="Origin note">
+  <p>This essay began with an <a href="https://x.com/tosinamuda/status/1846446706100961512?s=20">October 16, 2024 tweet</a> where I argued for the baby steps Nigeria can take in AI R&amp;D despite its power challenges.</p>
+
+  <p>In May 2026, I adapted that thought into an answer to one of the questions in Dwarkesh Patel's <a href="https://www.dwarkesh.com/p/blog-prize">Blog prize for the big questions about AI</a>: what countries outside the AI production chain should do to avoid being sidestepped by transformative AI.</p>
+</source-note>
+
+</blog-post>

--- a/src/builder/verify.js
+++ b/src/builder/verify.js
@@ -20,6 +20,7 @@ const REQUIRED = [
   "dist/components/site-footer.js",
   "dist/components/blog-archive.js",
   "dist/components/blog-post.js",
+  "dist/components/source-note.js",
   "dist/components/inec-collation.js",
   "dist/blog/inec-presidential-election-collation-architecture.html",
 ];

--- a/src/components/source-note.js
+++ b/src/components/source-note.js
@@ -1,0 +1,27 @@
+class SourceNote extends HTMLElement {
+  static get observedAttributes() {
+    return ["heading", "label"];
+  }
+
+  connectedCallback() {
+    this.dataset.enhanced = "true";
+    this.syncAccessibility();
+  }
+
+  attributeChangedCallback() {
+    if (!this.isConnected) return;
+    this.syncAccessibility();
+  }
+
+  syncAccessibility() {
+    const heading = this.getAttribute("heading") || this.getAttribute("label") || "Source note";
+
+    if (!this.hasAttribute("role")) this.setAttribute("role", "note");
+    if (!this.hasAttribute("aria-label") || this.dataset.ariaLabelSource === "heading") {
+      this.setAttribute("aria-label", heading);
+      this.dataset.ariaLabelSource = "heading";
+    }
+  }
+}
+
+customElements.define("source-note", SourceNote);

--- a/src/layouts/article.html
+++ b/src/layouts/article.html
@@ -25,6 +25,7 @@
     <script type="module" src="/components/blog-archive.js" defer crossorigin="anonymous"></script>
     <script type="module" src="/components/blog-post.js" defer crossorigin="anonymous"></script>
     <script type="module" src="/components/code-block.js" defer crossorigin="anonymous"></script>
+    <script type="module" src="/components/source-note.js" defer crossorigin="anonymous"></script>
     <script type="module" src="/components/inec-collation.js" defer crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/styles/00-fonts.css
+++ b/src/styles/00-fonts.css
@@ -1,3 +1,6 @@
+/* View transitions — smooth cross-fade between pages on same-origin nav */
+@view-transition { navigation: auto; }
+
 /* Cascade layers — explicit ordering, lowest priority first */
 @layer reset, tokens, base, components, utilities;
 

--- a/src/styles/00-fonts.css
+++ b/src/styles/00-fonts.css
@@ -1,6 +1,3 @@
-/* View transitions — smooth cross-fade between pages on same-origin nav */
-@view-transition { navigation: auto; }
-
 /* Cascade layers — explicit ordering, lowest priority first */
 @layer reset, tokens, base, components, utilities;
 

--- a/src/styles/30-components.css
+++ b/src/styles/30-components.css
@@ -210,6 +210,37 @@
   .note-page-body ul { padding-left: var(--space-5); }
   .note-page-body li { margin-bottom: var(--space-2); }
 
+  source-note {
+    display: block;
+    margin: var(--space-12) 0 0;
+    padding: var(--space-5) var(--space-6);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent);
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+    color: var(--ink-2);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+  }
+  source-note::before {
+    content: attr(heading);
+    display: block;
+    margin-bottom: var(--space-3);
+    font-family: var(--ui);
+    font-size: var(--text-xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  source-note:not([heading])::before {
+    content: attr(label);
+  }
+  source-note p {
+    margin: 0 0 1em;
+  }
+  source-note p:last-child {
+    margin-bottom: 0;
+  }
+
   .related {
     margin-top: var(--space-16);
     padding-top: var(--space-6);


### PR DESCRIPTION
## Summary

- Add the published May 2026 essay "How the Global South Can Enter the AI Value Chain: Nigeria’s Case".
- Add a reusable source-note web component with a passable heading attribute for note titles.
- Add the origin note to the Nigeria essay and a personal-views disclaimer to the Bob article.
- Keep the site’s automatic page view-transition rule enabled.

## Validation

- npm test
- Rendered the Nigeria and Bob article pages locally and verified both source notes, their aria labels, and no recent console errors.
- Opened the Bob article in Chrome and verified the disclaimer renders visibly with no recent console errors.